### PR TITLE
Use correct sub-path for environment list

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -45,7 +45,7 @@ export function activate(context: vscode.ExtensionContext) {
 		statusBarItem.show();
 	};
 
-	// tanka class for command -> apply, diff, show
+	// tanka class for command -> apply, prune, diff, show
 	const tanka = new Tanka(workspacePath!, outputChannel);
 
 	// context.subscriptions.push(vscode.workspace.onDidCloseTextDocument((e) => {
@@ -97,6 +97,20 @@ export function activate(context: vscode.ExtensionContext) {
 			return;
 		}
 		outputChannel.appendLine(stderr);
+		outputChannel.show();
+	});
+
+	registerCommand('vscode-tanka.env.prune', async (tankaNode: TankaNode) => {
+		showStatusBar('$(sync~spin) Tanka Pruning...', '');
+		const { code, stdout, stderr } = await tanka.prune(tankaNode.env);
+		statusBarItem.hide();
+
+		if (code == 0) {
+			outputChannel.appendLine(stdout);
+		}
+		else {
+			outputChannel.appendLine(stderr);
+		}
 		outputChannel.show();
 	});
 

--- a/src/tanka.ts
+++ b/src/tanka.ts
@@ -59,20 +59,26 @@ export class Tanka {
     }
 
     public async diff(env: TankaEnvironment) {
-        const args: string[] = ['tk', 'diff', path.join(this.rootPath, env.metadata.namespace), '--name', `${env.metadata.name}`];
+        const args: string[] = ['tk', 'diff', path.join(this.rootPath, env.metadata.namespace), '--log-level', 'warn', '--name', `${env.metadata.name}`];
         this.outputChannel.appendLine("command: " + args.join(' '));
         return await exec(args.join(' '));
     }
 
     public async apply(env: TankaEnvironment) {
-        const args: string[] = ['tk', 'apply', path.join(this.rootPath, env.metadata.namespace), '--name', `${env.metadata.name}`, '--dangerous-auto-approve'];
+        const args: string[] = ['tk', 'apply', path.join(this.rootPath, env.metadata.namespace), '--log-level', 'warn', '--name', `${env.metadata.name}`, '--auto-approve always'];
         this.outputChannel.appendLine("command: " + args.join(' '));
         this.outputChannel.show()
         return await exec(args.join(' '));
     }
 
     public async show(env: TankaEnvironment) {
-        const args: string[] = ['tk', 'show', path.join(this.rootPath, env.metadata.namespace), '--name', env.metadata.name, '--dangerous-allow-redirect'];
+        const args: string[] = ['tk', 'show', path.join(this.rootPath, env.metadata.namespace), '--log-level', 'warn', '--name', env.metadata.name, '--dangerous-allow-redirect'];
+        this.outputChannel.appendLine("command: " + args.join(' '));
+        return await exec(args.join(' '));
+    }
+
+    public async prune(env: TankaEnvironment) {
+        const args: string[] = ['tk', 'prune', path.join(this.rootPath, env.metadata.namespace), '--log-level', 'warn', '--name', env.metadata.name, '--auto-approve always'];
         this.outputChannel.appendLine("command: " + args.join(' '));
         return await exec(args.join(' '));
     }

--- a/src/tanka.ts
+++ b/src/tanka.ts
@@ -78,7 +78,7 @@ export class Tanka {
     }
 
     private async generateEnvironments() {
-        const args: string[] = ['tk', 'env', 'list', this.rootPath, '--json'];
+        const args: string[] = ['tk', 'env', 'list', this.rootPath + '/environments', '--json'];
         this.outputChannel.appendLine("command: " + args.join(' '));
         const { code, stdout, stderr } = await exec(args.join(' '));
         if (code === 0) {


### PR DESCRIPTION
Hi,

not sure if this is even still maintained.. But recent versions always throw an error on the `tk list enviroment ...` because it is using the wrong path. With this MR environments are at least visible and diff/apply/show also works.